### PR TITLE
add GeoJSON import & export

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -34,3 +34,21 @@ angular.module('CollaborativeMap', [
   });
 
 angular.module('SocketModule', []);
+
+/**
+ * Add helper function "safeApply" to the rootscope, so we
+ * can safely trigger $apply from external (leaflet) events.
+ * https://github.com/angular/angular.js/issues/2023
+ */
+angular.module('ng').run(function($rootScope) {
+  $rootScope.safeApply = function(fn) {
+    var phase = this.$root.$$phase;
+    if(phase == '$apply' || phase == '$digest') {
+      if(fn && (typeof(fn) === 'function')) {
+        fn();
+      }
+    } else {
+      this.$apply(fn);
+    }
+  };
+});

--- a/app/scripts/featureHistory/featureHistoryDirective.js
+++ b/app/scripts/featureHistory/featureHistoryDirective.js
@@ -7,7 +7,7 @@
  *
  * @requires ApiService
  * @requires MapHandler
- * 
+ *
  * @author Dennis Wilhelm
  */
 angular.module('CollaborativeMap')
@@ -339,7 +339,7 @@ angular.module('CollaborativeMap')
            * @return {Boolean}        true if there are geometry changes
            */
           $scope.hasGeomChanges = function(action) {
-            var geomChanges = ['created feature', 'deleted feature', 'edited geometry', 'restored'];
+            var geomChanges = ['created feature', 'deleted feature', 'edited geometry', 'restored', 'imported feature'];
             return geomChanges.indexOf(action) > -1;
           };
 

--- a/app/scripts/featureProperties/featurePropertiesDirective.js
+++ b/app/scripts/featureProperties/featurePropertiesDirective.js
@@ -26,11 +26,11 @@ angular.module('CollaborativeMap')
 
           function activateToolbox() {
             if ($scope.views.toolBarIn) {
-              $scope.toggleToolbar('toolsView');
-              $scope.$apply();
-            } else if ($scope.views.toolsView) {
-              $scope.toggleToolbar('toolsView');
-              $scope.$apply();
+              $scope.toggleToolbar('propertiesView');
+              $scope.safeApply();
+            } else if ($scope.views.propertiesView) {
+              $scope.toggleToolbar('propertiesView');
+              $scope.safeApply();
             }
 
           }
@@ -97,18 +97,13 @@ angular.module('CollaborativeMap')
             $scope.editByUser = editByUser;
 
             //$apply has to be called manually, if the function is called from a different event (here leaflet click)
-            if ($scope.$root.$$phase !== '$apply' && $scope.$root.$$phase !== '$digest') {
-              $scope.$apply();
-            }
-
+            $scope.safeApply();
           };
 
           $scope.$on('editHandlerUpdate', function(event, data) {
             $scope.editByUser = data;
             //$apply has to be called manually, if the function is called from a different event (here leaflet click)
-            if ($scope.$root.$$phase !== '$apply' && $scope.$root.$$phase !== '$digest') {
-              $scope.$apply();
-            }
+            $scope.safeApply();
           });
 
 
@@ -167,8 +162,7 @@ angular.module('CollaborativeMap')
           $scope.deleteFeature = function() {
             MapHandler.deleteFeature();
             $scope.selectedFeature = undefined;
-            $scope.toggleToolbar('toolsView');
-
+            $scope.toggleToolbar('propertiesView');
           };
 
           /**
@@ -266,7 +260,7 @@ angular.module('CollaborativeMap')
            */
 
           function hideStopEditingBtn() {
-            $('#stopEditBtn')[0].className += ' hidden';
+            $('#stopEditBtn').addClass('hidden');
           }
 
           /**
@@ -295,7 +289,7 @@ angular.module('CollaborativeMap')
            * Cancel the edit mode if the toolbox window is closed.
            */
           $scope.$on('toolbox', function() {
-            if ($scope.views.toolsView) {
+            if ($scope.views.propertiesView) {
               MapHandler.removeEditHandler();
             }
           });

--- a/app/scripts/leaflet/mapDirective.js
+++ b/app/scripts/leaflet/mapDirective.js
@@ -7,16 +7,16 @@
  * Loads already existing features from the Database.
  * Initializes the map Synchronization and the MapHandler
  * @exports CollaborativeMap.MapDirective
- * 
+ *
  * @requires  ApiService
  * @requires MapHandler
  * @requires SynchronizeMap
- * 
+ *
  * @author Dennis Wilhelm
  */
 angular.module('CollaborativeMap')
-  .directive('map', ['MapHandler', 'SynchronizeMap', 'ApiService',
-    function(MapHandler, SynchronizeMap, ApiService) {
+  .directive('map', ['MapHandler', 'SynchronizeMap', 'ApiService', 'DataImport',
+    function(MapHandler, SynchronizeMap, ApiService, DataImport) {
       var mapLoadingDiv;
 
       /**
@@ -39,6 +39,7 @@ angular.module('CollaborativeMap')
             }, drawnItems);
           })
           .done(function() {
+            map.fitBounds(drawnItems.getBounds());
             removeLoading();
           });
       }
@@ -46,7 +47,6 @@ angular.module('CollaborativeMap')
       /**
        * Creates a loading div
        */
-
       function showLoading() {
         mapLoadingDiv = document.createElement('div');
         mapLoadingDiv.className = 'mapLoading';
@@ -59,7 +59,6 @@ angular.module('CollaborativeMap')
       /**
        * Removes the loading div from the page
        */
-
       function removeLoading() {
         document.body.removeChild(mapLoadingDiv);
       }
@@ -98,8 +97,8 @@ angular.module('CollaborativeMap')
           }, {}, {
             position: 'topleft'
           }).addTo(map);
-         
-         map.infoControl.setPosition('bottomleft');
+
+          map.infoControl.setPosition('bottomleft');
           // Initialise the FeatureGroup to store editable layers
           var drawnItems = window.drawnItems = new L.FeatureGroup();
           map.addLayer(drawnItems);
@@ -153,6 +152,8 @@ angular.module('CollaborativeMap')
           //Initialize the map synchronization (handles all Websocket related sync stuff)
           SynchronizeMap.init(map, $scope.$parent, drawnItems);
 
+          //Pass the map instance to the DataImporter
+          DataImport.init(map);
         }
       };
     }

--- a/app/scripts/leaflet/mapDirective.js
+++ b/app/scripts/leaflet/mapDirective.js
@@ -28,9 +28,10 @@ angular.module('CollaborativeMap')
 
       function loadFeatures(mapId, map, drawnItems) {
         showLoading();
+        var featuresLength = 0;
         ApiService.getFeaturesOboe(mapId)
           .node('rows.*', function(row) {
-
+            featuresLength++;
             // This callback will be called everytime a new object is
             // found in the foods array.
             MapHandler.addGeoJSONFeature(map, {
@@ -39,7 +40,7 @@ angular.module('CollaborativeMap')
             }, drawnItems);
           })
           .done(function() {
-            map.fitBounds(drawnItems.getBounds());
+            if (featuresLength) map.fitBounds(drawnItems.getBounds());
             removeLoading();
           });
       }
@@ -153,7 +154,7 @@ angular.module('CollaborativeMap')
           SynchronizeMap.init(map, $scope.$parent, drawnItems);
 
           //Pass the map instance to the DataImporter
-          DataImport.init(map);
+          DataImport.init(map, drawnItems);
         }
       };
     }

--- a/app/scripts/leaflet/mapDrawEventsService.js
+++ b/app/scripts/leaflet/mapDrawEventsService.js
@@ -2,12 +2,12 @@
 
 /**
  * @memberof CollaborativeMap
- * 
+ *
  * @fileOverview Adds listeners for all leaflet specific draw events.
- * 
+ *
  * Adds click handlers for new features (through the MapHandler).
  * Edit/delete events call a Callback (further handling is done in the SynchronizeMapService)
- * 
+ *
  * @exports CollaborativeMap.MapHandler
  * @requires  MapHandler
  * @author Dennis Wilhelm
@@ -40,7 +40,7 @@ angular.module('CollaborativeMap')
          * Listens for leaflet draw events. Packs the events in a message and calls the callback
          * @param  {Object}   map      the map
          * @param  {Object}   scope    Angular scope
-         * @param  {Function} callback 
+         * @param  {Function} callback
          */
         connectMapEvents: function(map, scope, callback) {
           mapScope = scope;
@@ -48,7 +48,7 @@ angular.module('CollaborativeMap')
           map.on('draw:created', function(event) {
             scope.selectFeature(event.layer);
             MapHandler.addClickEvent(event.layer);
-            callback(eventToMessage(event, 'created feature'));
+            callback(eventToMessage(event, event.action || 'created feature'));
           });
 
           map.on('draw:edited', function(event) {

--- a/app/scripts/leaflet/mapMovementEventsService.js
+++ b/app/scripts/leaflet/mapMovementEventsService.js
@@ -2,11 +2,11 @@
 
 /**
  * @memberof CollaborativeMap
- * 
- * @fileOverview Listeners for mouse drage and scroll events to catch map movements. 
- * Used instead of direct leaflet events to prevent back coupling problems. 
+ *
+ * @fileOverview Listeners for mouse drage and scroll events to catch map movements.
+ * Used instead of direct leaflet events to prevent back coupling problems.
  * Callbacks of all events are handled in the SynchronizeMapService.
- * 
+ *
  * @exports CollaborativeMap.MapMovementEvents
  * @author Dennis Wilhelm
  */
@@ -20,68 +20,16 @@ angular.module('CollaborativeMap')
        * @param  {Function} callback
        */
       connectMapEvents: function(map, callback) {
-
-        var element = map._container;
-
-        this.addDragEvent(map, element, callback);
-        this.addScrollEvent(map, element, callback);
-
+        // catches any map movements (drag, zoom, resize, ...)
+        map.on('moveend', function(e) {
+          var bounds = map.getBounds();
+          callback({
+            'nE': [bounds._northEast.lat, bounds._northEast.lng],
+            'sW': [bounds._southWest.lat, bounds._southWest.lng]
+          });
+        });
       },
 
-      /**
-       * Adds the mouse listeners. If drag is catched, get the map bounds and fire the callback
-       * @param {Object}   map      the map
-       * @param {Object}   element  html element
-       * @param {Function} callback
-       */
-      addDragEvent: function(map, element, callback) {
-        var flag = 0;
-
-        element.addEventListener('mousedown', function() {
-          flag = 0;
-        }, false);
-        element.addEventListener('mousemove', function() {
-          flag = 1;
-        }, false);
-        element.addEventListener('mouseup', function() {
-          if (flag === 0) {
-            //click
-          } else if (flag === 1) {
-            //If a drag has been performed, upload the new map-position
-            callback(this.getBoundsMessage(map));
-          }
-        }.bind(this), false);
-      },
-
-      /**
-       * Adds the scroll listeners. If scroll is catched, get the map bounds and fire the callback
-       * @param {Object}   map      the map
-       * @param {Object}   element  html element
-       * @param {Function} callback 
-       */
-      addScrollEvent: function(map, element, callback) {
-        element.addEventListener('mousewheel', function() {
-          callback(this.getBoundsMessage(map));
-        }.bind(this), false);
-
-        element.addEventListener('DOMMouseScroll', function() {
-          callback(this.getBoundsMessage(map));
-        }.bind(this), false);
-
-      },
-
-      /**
-       * Get the current bounding box of the map
-       * @param  {Object} map the map
-       * @return {Object}     bounding box {nE, sW}
-       */
-      getBoundsMessage: function(map) {
-        var bounds = map.getBounds();
-        return {
-          'nE': [bounds._northEast.lat, bounds._northEast.lng],
-          'sW': [bounds._southWest.lat, bounds._southWest.lng]
-        };
-      }
 
     };
   });

--- a/app/scripts/leaflet/synchronizeMapService.js
+++ b/app/scripts/leaflet/synchronizeMapService.js
@@ -46,7 +46,6 @@ angular.module('CollaborativeMap')
       /**
        * Stores the mapBounds of a user. If the user is being watched, update the current map bounds
        * @param  {Object} movement = {event: {nE, sW, userId}}
-       * @param  {Object} map
        */
 
       function handleMapMovements(movement) {
@@ -63,7 +62,6 @@ angular.module('CollaborativeMap')
       /**
        * Connects to the Websocket mapMovement channel
        * @param  {String} mapId
-       * @param  {Object} map
        */
 
       function receiveMapMovements(mapId) {
@@ -98,7 +96,7 @@ angular.module('CollaborativeMap')
        * @param  {Object} event = mapDraw event
        */
 
-      function updateToolsView(map, event) {
+      function updatePropertiesView(map, event) {
         //without a timeout, the autobinding of angular doesn't seem to work
         setTimeout(function() {
           mapScope.selectFeature(map._layers[event.fid]);
@@ -114,9 +112,9 @@ angular.module('CollaborativeMap')
 
       function refreshToolbox(map, event) {
         var views = mapScope.views;
-        if (!views.toolsView) {
+        if (!views.propertiesView) {
           if (mapScope.selectedFeature.fid === event.fid) {
-            updateToolsView(map, event);
+            updatePropertiesView(map, event);
           }
         }
       }

--- a/app/scripts/leaflet/synchronizeMapService.js
+++ b/app/scripts/leaflet/synchronizeMapService.js
@@ -137,7 +137,7 @@ angular.module('CollaborativeMap')
 
             var event = res.event;
 
-            if (event.action === 'created' || event.action === 'created feature') {
+            if (event.action === 'created' || event.action === 'created feature' || event.action === 'imported feature') {
 
               MapHandler.addGeoJSONFeature(map, event, drawnItems, false, Users.getUserColorByName(res.event.user));
 

--- a/app/scripts/toolbox/DataImportService.js
+++ b/app/scripts/toolbox/DataImportService.js
@@ -1,0 +1,46 @@
+/**
+ * @memberof CollaborativeMap
+ * @fileOverview Data import directive.
+ * Provides import functionality to the map.
+ * Supported formats are currently: GeoJSON
+ * @exports CollaborativeMap.DataImport
+ *
+ * @author Norwin Roosen
+ */
+
+'use strict';
+
+angular.module('CollaborativeMap')
+  .service('DataImport', ['MapHandler', 'Utils',
+    function(MapHandler, Utils) {
+
+      var map;
+
+      return {
+        init: function(mapInstance) {
+          map = mapInstance;
+        },
+
+        /**
+         * Create MapObjects from external geoJSON resources,
+         * which are not from the draw toolbar nor database, and thus have no FID.
+         * @param {Object} data The (valid) GeoJSON data
+         */
+        importGeoJson: function(data) {
+          var geojson = MapHandler.createSimpleStyleGeoJSONFeature(data);
+
+          // fake a draw event, so we can reuse the existing signaling pipeline:
+          // (add to map, clickhandlers, broadcast to other users, ..)
+          geojson.eachLayer(function(layer) {
+            map.fire('draw:created', {
+              action: 'imported feature',
+              layer: layer
+            });
+          });
+
+          map.fitBounds(geojson);
+        }
+      };
+
+    }]
+  );

--- a/app/scripts/toolbox/DataImportService.js
+++ b/app/scripts/toolbox/DataImportService.js
@@ -14,11 +14,12 @@ angular.module('CollaborativeMap')
   .service('DataImport', ['MapHandler', 'Utils',
     function(MapHandler, Utils) {
 
-      var map;
+      var map, drawnItems;
 
       return {
-        init: function(mapInstance) {
+        init: function(mapInstance, drawn) {
           map = mapInstance;
+          drawnItems = drawn;
         },
 
         /**
@@ -39,6 +40,11 @@ angular.module('CollaborativeMap')
           });
 
           map.fitBounds(geojson);
+        },
+
+        exportGeoJson: function() {
+          // TODO: strip internal attributes (_rev, _id, user, ...)
+          return drawnItems.toGeoJSON();
         }
       };
 

--- a/app/scripts/toolbox/chatDirective.js
+++ b/app/scripts/toolbox/chatDirective.js
@@ -8,7 +8,7 @@
  * @requires Socket
  * @requires MapHandler
  * @requires Tooltip
- * 
+ *
  * @author Dennis Wilhelm
  */
 angular.module('CollaborativeMap')
@@ -109,7 +109,7 @@ angular.module('CollaborativeMap')
               },50);
               Tooltip.hideTooltip();
               $scope.isReferTo = false;
-              $scope.$apply();
+              $scope.safeApply();
             });
           };
 

--- a/app/scripts/toolbox/toolboxDirective.js
+++ b/app/scripts/toolbox/toolboxDirective.js
@@ -65,6 +65,7 @@ angular.module('CollaborativeMap')
             userView: true,
             historyView: true,
             toolBarIn: true,
+            propertiesView: true,
             toolsView: true
           };
 

--- a/app/scripts/toolbox/toolboxDirective.js
+++ b/app/scripts/toolbox/toolboxDirective.js
@@ -119,7 +119,7 @@ angular.module('CollaborativeMap')
             if (bounds) {
               MapHandler.paintUserBounds(bounds, Users.getUserById(userId).color || 'undefined');
             } else {
-              window.alert('The user hasn\'t mooved since you logged in');
+              window.alert('The user hasn\'t moved since you logged in');
             }
           };
 

--- a/app/scripts/toolbox/toolsDirective.js
+++ b/app/scripts/toolbox/toolsDirective.js
@@ -36,6 +36,10 @@ angular.module('CollaborativeMap')
             }
           };
 
+          $scope.exportMap = function() {
+            $scope.dataInputField = JSON.stringify(DataImport.exportGeoJson(), null, 2);
+          };
+
         }
       };
     }

--- a/app/scripts/toolbox/toolsDirective.js
+++ b/app/scripts/toolbox/toolsDirective.js
@@ -1,0 +1,42 @@
+'use strict';
+
+/**
+ * @memberof CollaborativeMap
+ * @fileOverview Tools directive. Provides GUI functionality to various tools (import/export)
+ * @exports CollaborativeMap.tools
+ *
+ * @requires MapHandler
+ * @requires DataImport
+ *
+ * @author Norwin Roosen
+ */
+angular.module('CollaborativeMap')
+  .directive('tools', ['DataImport',
+    function(DataImport) {
+      return {
+        templateUrl: 'partials/tools',
+        restrict: 'E',
+        scope: {},
+        link: function postLink($scope) {
+          $scope.dataInputField = '';
+          $scope.jsonError = '';
+
+          /**
+           * takes a GeoJSON string from the toolbox input field
+           * and adds the data to the map
+           */
+          $scope.importDataString = function() {
+            var data = $scope.dataInputField;
+            try {
+              DataImport.importGeoJson(JSON.parse(data));
+              $scope.jsonError = '';
+              $scope.dataInputField = '';
+            } catch (err) {
+              $scope.jsonError = 'invalid geojson: ' + err;
+            }
+          };
+
+        }
+      };
+    }
+  ]);

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -121,7 +121,7 @@ input {
   top: 50px;
   bottom: 0;
   height: 100%;
-  width: 375px;
+  width: 381px;
   background-color: rgba(231, 231, 231, 0.9);
   z-index: 1000;
 }
@@ -130,7 +130,7 @@ input {
   right: -3px;
   top: 0;
   background-color: rgb(60, 78, 90);
-  width: 378px;
+  width: 381px;
   height: 50px;
 }
 .animate-slideIn {

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -237,12 +237,16 @@ input {
 }
 .tools {
   margin: 10px;
-  padding-right: 8px;
+}
+.tools .btn {
+  margin: 0;
 }
 .tools textarea {
+  font-family: monospace;
   resize: vertical;
   border:1px solid #999999;
   width:100%;
+  height: 200px;
   margin:5px 0;
   padding:3px;
 }
@@ -303,7 +307,7 @@ input {
 .propertyLabel {
   display: block;
   background-color: rgb(192, 192, 192);
-  width: 265px;
+  width: 100%;
   border-radius: 0;
   margin: 0;
   height: 25px;
@@ -503,7 +507,7 @@ select {
 .featureProperties {
   position: absolute;
   overflow-y: auto;
-  bottom: 210px;
+  bottom: 60px;
   top: 10px;
 }
 .mapLoading {

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -121,7 +121,7 @@ input {
   top: 50px;
   bottom: 0;
   height: 100%;
-  width: 300px;
+  width: 375px;
   background-color: rgba(231, 231, 231, 0.9);
   z-index: 1000;
 }
@@ -130,7 +130,7 @@ input {
   right: -3px;
   top: 0;
   background-color: rgb(60, 78, 90);
-  width: 303px;
+  width: 378px;
   height: 50px;
 }
 .animate-slideIn {
@@ -183,7 +183,7 @@ input {
 }
 .toolbox-content {
   margin-top: 20px;
-  width: 300px;
+  width: 375px;
   max-height: 290;
   overflow: auto;
 }
@@ -201,6 +201,8 @@ input {
 }
 .chat {
   position: absolute;
+  width: 100%;
+  padding: 10px 10px 10px 10px;
   bottom: 50px;
 }
 .chatMessages {
@@ -208,10 +210,7 @@ input {
   position: absolute;
   top: 250px;
   bottom: 150px;
-  width: 300px;
-}
-.chatNew {
-  margin-left: 10px;
+  width: 100%;
 }
 .history {
   background-color: #FFFFFF;
@@ -235,6 +234,17 @@ input {
   bottom: 60px;
   top: 10px;
   overflow: auto;
+}
+.tools {
+  margin: 10px;
+  padding-right: 8px;
+}
+.tools textarea {
+  resize: vertical;
+  border:1px solid #999999;
+  width:100%;
+  margin:5px 0;
+  padding:3px;
 }
 .btn {
   border-radius: 0;
@@ -477,7 +487,7 @@ select {
 }
 .slider {
   position: fixed;
-  right: 300px;
+  right: 375px;
   top: 50px;
   bottom: 0;
   padding: 5px;

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -79,6 +79,8 @@
   <script src="scripts/toolbox/chatDirective.js"></script>
   <script src="scripts/toolbox/chatMessageDirective.js"></script>
   <script src="scripts/toolbox/tooltipService.js"></script>
+  <script src="scripts/toolbox/DataImportService.js"></script>
+  <script src="scripts/toolbox/toolsDirective.js"></script>
   <script src="scripts/toolbox/userService.js"></script>
   <script src="scripts/socketio/socketio.js"></script>
   <script src="scripts/socketio/socketStatusDirective.js"></script>

--- a/app/views/partials/chat.html
+++ b/app/views/partials/chat.html
@@ -6,14 +6,14 @@
     <br>
     <chat-message message="message"></chat-message>
   </div>
-  <div ng-hide="messages.length">Start typing in the input field below to start chatting with other users in this map.</div>
-
-</div>
-<div class="chat">
-  <div class="chatNew">
-    <input type="text" ng-model="chatMessage" ng-keypress="sendMessage($event)" style="width: 250px;"><br>
-    <input type="button" class="btn btn-default" ng-show="isReferTo" ng-click="cancelReferToFeature()" value="Cancel referring">
-    <input type="button" class="btn btn-default" ng-hide="isReferTo" ng-click="referToFeature()" value="Refer to feature">
-    <input type="button" class="btn btn-default" ng-click="sendMessage()" value="Send" style="float:right;">
+  <div ng-hide="messages.length" style="padding: 10px">
+    Start typing in the input field below to start chatting with other users in this map.
   </div>
+</div>
+
+<div class="chat">
+  <input type="text" ng-model="chatMessage" ng-keypress="sendMessage($event)" style="width: 100%;"><br>
+  <input type="button" class="btn btn-default" ng-show="isReferTo" ng-click="cancelReferToFeature()" value="Cancel referring">
+  <input type="button" class="btn btn-default" ng-hide="isReferTo" ng-click="referToFeature()" value="Refer to feature">
+  <input type="button" class="btn btn-default" ng-click="sendMessage()" value="Send" style="float:right;">
 </div>

--- a/app/views/partials/toolbox.html
+++ b/app/views/partials/toolbox.html
@@ -2,10 +2,9 @@
   <div class="toolbox-buttons">
     <input type="button" class="btn btn-dark" ng-click="toggleToolbar('userView')" value="Users" data-intro='Shows all users within this map and provides a chat function. The watch function within this tab allows you to keep the current map synchronized with another user. <br><a href="images/users.gif" target="_blank">Demo</a>' data-step="2">
     <input type="button" class="btn btn-dark" ng-click="toggleToolbar('historyView')" value="History" data-intro='Shows all actions performed in this map.<br><a href="images/history.gif" target="_blank">Demo</a>' data-step="3">
-    <input type="button" class="btn btn-dark" ng-click="toggleToolbar('toolsView')" value="Feature" data-intro='Edit or delete the properties of a single feature within the map. This view will automatically open if you click on a feature in the map.<br><a href="images/feature.gif" target="_blank">Demo</a>' data-step="4">
+    <input type="button" class="btn btn-dark" ng-click="toggleToolbar('propertiesView')" value="Feature" data-intro='Edit or delete the properties of a single feature within the map. This view will automatically open if you click on a feature in the map.<br><a href="images/feature.gif" target="_blank">Demo</a>' data-step="4">
+    <input type="button" class="btn btn-dark" ng-click="toggleToolbar('toolsView')" value="Tools" data-intro='Shows various tools (data import/export).' data-step="5">
     <input type="button" class="btn btn-dark" ng-click="startIntroJS()" value="Help">
-    <!--
-  <input type="button" class="btn btn-dark" ng-click="toggleToolbar('settingsView')" value="Settings">-->
   </div>
   <div id="toolbox" class="toolbox animate-slideIn" ng-class="{'zeroWidth':views.toolBarIn}">
 
@@ -28,8 +27,11 @@
     <div class="toolbox-content" ng-class="{'hide': views.historyView}">
       <map-history></map-history>
     </div>
-    <div class="toolbox-content" ng-class="{'hide': views.toolsView}">
+    <div class="toolbox-content" ng-class="{'hide': views.propertiesView}">
       <featureproperties></featureproperties>
+    </div>
+    <div class="toolbox-content" ng-class="{'hide': views.toolsView}">
+      <tools></tools>
     </div>
   </div>
 </div>

--- a/app/views/partials/tools.html
+++ b/app/views/partials/tools.html
@@ -1,6 +1,7 @@
 <div class="tools">
-  <h4>Import GeoJSON</h4>
+  <h4>GeoJSON import / export</h4>
   <textarea ng-model="dataInputField" placeholder="...paste some valid GeoJSON here"></textarea>
   <div class="orangeBackground">{{jsonError}}</div>
-  <input class="btn btn-default" type="button" value="Import" ng-click="importDataString()"/>
+  <input class="btn btn-default" type="button" value="Import into map" ng-click="importDataString()"/>
+  <input class="btn btn-default" type="button" value="Export map" ng-click="exportMap()"/>
 </div>

--- a/app/views/partials/tools.html
+++ b/app/views/partials/tools.html
@@ -1,0 +1,6 @@
+<div class="tools">
+  <h4>Import GeoJSON</h4>
+  <textarea ng-model="dataInputField" placeholder="...paste some valid GeoJSON here"></textarea>
+  <div class="orangeBackground">{{jsonError}}</div>
+  <input class="btn btn-default" type="button" value="Import" ng-click="importDataString()"/>
+</div>

--- a/lib/config/express.js
+++ b/lib/config/express.js
@@ -9,7 +9,12 @@ var express = require('express'),
  */
 module.exports = function(app) {
   app.configure('development', function(){
-    app.use(require('connect-livereload')());
+    app.use(require('connect-livereload')({
+      // livereload is incompatible with the current method
+      // of streaming data from the API for some maps.
+      // see https://github.com/mscdex/busboy/issues/79#issuecomment-108684031
+      ignore: [/api/],
+    }));
 
     // Disable caching of scripts for easier testing
     app.use(function noCache(req, res, next) {


### PR DESCRIPTION
I added functionality to import geojson data into the map. This enables the reuse of existing datasets in/from other applications.

To do so, a new sidebar panel "Tools" is introduced:
![screenshot from 2016-09-01 19-57-10](https://cloud.githubusercontent.com/assets/7880552/18178526/02dd6b78-707f-11e6-9a8c-1b59cbe0533c.png)

Also, some other improvements were made:
- improve propagation of mapview-changes to other users, by using leaflets event API instead of native browser events. now *all* map movements are registered
- fit the mapview to all features when loading a non-empty map
- fixed edgecases where multiple simultaneous `$scope.$apply()` calls were made, resulting in buggy UI
- fix corrupted API stream in `development` env, which was introduced by `connect-livereload` injection