### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/How_does_it_work.md
+++ b/How_does_it_work.md
@@ -1,7 +1,7 @@
 How does it work?
 =========
 
-###Synchronization
+### Synchronization
 Ethermap makes heavy use of WebSockets to synchronize the map editor between all clients. socket.io as a library has been chosen for the automatic fallback to Long-Polling.
 
 Within Leaflet, the L.stamp function has been adapted to provide unique layer id's which are required to synchronize the map content between different clients. Based on the Leaflet.Draw events, all changes are sent to the server, where they are stored in CouchDB and distributed again via WebSockets. Leaflet.Draw has however been modified to allow only one feature to be edited at a time. In addition to that, every change will be transmitted. Usually Leaflet.Draw only applies changes after hitting "Save".
@@ -10,7 +10,7 @@ Features are transferred as GeoJSON objects.
 
 To watch users or show there current workarea, all movements (panning/zooming) are also transferred with the current bounding box of the map window. To prevent feedback, custom event listeners have been used instead of the existing Leaflet events. 
 
-###Version-control
+### Version-control
 For the feature history, every change is stored as a new document revision in CouchDB and thus can be requested individually. This works as long as no "Compaction" operation will be applied to the database in which case all older revisions would be deleted. The diffs are calculated dynamically on the client side.
 
 For the global map history, all feature actions are stored within a seperate database to allow the creation of a map history. To prevent a cluttering of the list, subsequent entries of a single user are aggregated on the client side. Possible actions are: 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For a [demo](http://giv-wilhelm.uni-muenster.de) (desktop only), open the websit
 The application has been built as part of my master thesis at the ifgi (Institute for Geoinformatics, WWU Münster).
 
 
-###Technologies
+### Technologies
 
 * [node.js]
 * [Leaflet] + [Leaflet.draw]
@@ -30,7 +30,7 @@ The application has been built as part of my master thesis at the ifgi (Institut
 
 
 
-###Install dependencies (Ubuntu)
+### Install dependencies (Ubuntu)
 
 It is assumed that you have installed node.js (developed using 0.10.26)
 ```
@@ -42,7 +42,7 @@ npm install -g forever
 ```
 
 
-###Run for Development
+### Run for Development
 
 
 ```
@@ -52,7 +52,7 @@ grunt serve
 
 ```
 
-###Run for Production
+### Run for Production
 
 
 ```
@@ -73,7 +73,7 @@ sudo fig up
 Ethermap will be available from http://localhost:8080
 
 
-###Testing
+### Testing
 
 Tests are based on Karma + Jasmine
 
@@ -87,14 +87,14 @@ npm install -g karma-cli
 karma start
 ```
 
-###Create the JSDoc pages
+### Create the JSDoc pages
 
 ```
 grunt docs
 ```
 
 
-###License
+### License
 
 [Apache v2.0](license.md) - Dennis Wilhelm 2014
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
